### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
     <!-- release parent settings -->
     <version.java>11</version.java>
     <nexus.snapshot.repository>
-      https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/
+      https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
     </nexus.snapshot.repository>
-    <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/
+    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/
     </nexus.release.repository>
 
     <!-- disable jdk8 javadoc checks on release build -->
@@ -341,7 +341,7 @@
     <repository>
       <id>zeebe</id>
       <name>Zeebe Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -353,7 +353,7 @@
     <repository>
       <id>zeebe-snapshots</id>
       <name>Zeebe Snapshot Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
We created a new domain name for our repository manager (Artifactory) to replace the old Nexus proxy URL (app.camunda.com/nexus). The proxy URL will be removed in the future. 

Related to INFRA-3114



