### PR TITLE
fix: store checksum as byte array

### DIFF
--- a/src/main/java/io/zeebe/exporter/proto/RecordTransformer.java
+++ b/src/main/java/io/zeebe/exporter/proto/RecordTransformer.java
@@ -247,7 +247,7 @@ public final class RecordTransformer {
         .setResourceName(processMetadata.getResourceName())
         .setVersion(processMetadata.getVersion())
         .setProcessDefinitionKey(processMetadata.getProcessDefinitionKey())
-        .setChecksum(new String(processMetadata.getChecksum()))
+        .setChecksum(ByteString.copyFrom(processMetadata.getChecksum()))
         .build();
   }
 
@@ -281,7 +281,7 @@ public final class RecordTransformer {
         .setResource(ByteString.copyFrom(value.getResource()))
         .setVersion(value.getVersion())
         .setProcessDefinitionKey(value.getProcessDefinitionKey())
-        .setChecksum(new String(value.getChecksum()))
+        .setChecksum(ByteString.copyFrom(value.getChecksum()))
         .setMetadata(toMetadata(record))
         .build();
   }
@@ -554,7 +554,7 @@ public final class RecordTransformer {
         .setDecisionRequirementsKey(metadataValue.getDecisionRequirementsKey())
         .setNamespace(metadataValue.getNamespace())
         .setResourceName(metadataValue.getResourceName())
-        .setChecksum(new String(metadataValue.getChecksum()))
+        .setChecksum(ByteString.copyFrom(metadataValue.getChecksum()))
         .setIsDuplicate(metadataValue.isDuplicate())
         .build();
   }

--- a/src/main/proto/schema.proto
+++ b/src/main/proto/schema.proto
@@ -83,7 +83,7 @@ message DeploymentRecord {
     int32 version = 2;
     int64 processDefinitionKey = 3;
     string resourceName = 5;
-    string checksum = 6;
+    bytes checksum = 6;
     bool isDuplicate = 7;
   }
 
@@ -287,7 +287,7 @@ message ProcessRecord {
   int32 version = 3;
   int64 processDefinitionKey = 4;
   string resourceName = 5;
-  string checksum = 6;
+  bytes checksum = 6;
   bytes resource = 7;
 }
 
@@ -318,7 +318,7 @@ message DecisionRequirementsMetadata {
   int64 decisionRequirementsKey = 4;
   string namespace = 5;
   string resourceName = 6;
-  string checksum = 7;
+  bytes checksum = 7;
   bool isDuplicate = 8;
 }
 

--- a/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
+++ b/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
@@ -130,7 +130,7 @@ public class RecordTransformTest {
     assertThat(processMetadata.getResourceName()).isEqualTo("process.bpmn");
     assertThat(processMetadata.getProcessDefinitionKey()).isEqualTo(4L);
     assertThat(processMetadata.getVersion()).isEqualTo(1);
-    assertThat(processMetadata.getChecksum()).isEqualTo("checksum");
+    assertThat(processMetadata.getChecksum().toByteArray()).isEqualTo("checksum".getBytes());
     assertThat(processMetadata.getIsDuplicate()).isFalse();
 
     final var decisionRequirementsMetadataList = deployment.getDecisionRequirementsMetadataList();
@@ -152,7 +152,7 @@ public class RecordTransformTest {
         .isEqualTo(decisionRequirementsMetadata.getNamespace());
     assertThat(transformedDecisionRequirementsMetadata.getResourceName())
         .isEqualTo(decisionRequirementsMetadata.getResourceName());
-    assertThat(transformedDecisionRequirementsMetadata.getChecksum().getBytes())
+    assertThat(transformedDecisionRequirementsMetadata.getChecksum().toByteArray())
         .isEqualTo(decisionRequirementsMetadata.getChecksum());
     assertThat(transformedDecisionRequirementsMetadata.getIsDuplicate())
         .isEqualTo(decisionRequirementsMetadata.isDuplicate());
@@ -217,7 +217,7 @@ public class RecordTransformTest {
     assertThat(transformedRecord.getResource().toStringUtf8()).isEqualTo("resourceContent");
     assertThat(transformedRecord.getResourceName()).isEqualTo(recordValue.getResourceName());
     assertThat(transformedRecord.getBpmnProcessId()).isEqualTo(recordValue.getBpmnProcessId());
-    assertThat(transformedRecord.getChecksum()).isEqualTo("checksum");
+    assertThat(transformedRecord.getChecksum().toByteArray()).isEqualTo("checksum".getBytes());
     assertThat(transformedRecord.getProcessDefinitionKey())
         .isEqualTo(recordValue.getProcessDefinitionKey());
     assertThat(transformedRecord.getVersion()).isEqualTo(recordValue.getVersion());
@@ -678,7 +678,7 @@ public class RecordTransformTest {
         .isEqualTo(recordValue.getNamespace());
     assertThat(transformedRecord.getDecisionRequirementsMetadata().getResourceName())
         .isEqualTo(recordValue.getResourceName());
-    assertThat(transformedRecord.getDecisionRequirementsMetadata().getChecksum().getBytes())
+    assertThat(transformedRecord.getDecisionRequirementsMetadata().getChecksum().toByteArray())
         .isEqualTo(recordValue.getChecksum());
     assertThat(transformedRecord.getDecisionRequirementsMetadata().getIsDuplicate())
         .isEqualTo(recordValue.isDuplicate());


### PR DESCRIPTION
* the checksum is stored as a byte array in the records
* avoid transforming it into a string to avoid encoding issues