### PR TITLE
Support multi-tenancy in Zeebe 8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 
     <!-- project dependencies -->
-    <version.zeebe>8.2.3</version.zeebe>
+    <version.zeebe>8.3.5</version.zeebe>
 
     <version.protobuf>3.25.1</version.protobuf>
     <version.protoc>3.9.1</version.protoc>

--- a/src/main/proto/schema.proto
+++ b/src/main/proto/schema.proto
@@ -92,6 +92,7 @@ message DeploymentRecord {
     string resourceName = 5;
     bytes checksum = 6;
     bool isDuplicate = 7;
+    string tenantId = 8;
   }
 
   message DecisionMetadata {
@@ -102,6 +103,7 @@ message DeploymentRecord {
     string decisionRequirementsId = 5;
     int64 decisionRequirementsKey = 6;
     bool isDuplicate = 7;
+    string tenantId = 8;
   }
 
   RecordMetadata metadata = 1;
@@ -109,6 +111,7 @@ message DeploymentRecord {
   repeated ProcessMetadata processMetadata = 3;
   repeated DecisionRequirementsMetadata decisionRequirementsMetadata = 4;
   repeated DecisionMetadata decisionMetadata = 5;
+  string tenantId = 6;
 }
 
 message DeploymentDistributionRecord {
@@ -140,6 +143,7 @@ message IncidentRecord {
   int64 jobKey = 8;
   int64 processDefinitionKey = 9;
   int64 variableScopeKey = 10;
+  string tenantId = 11;
 }
 
 message JobRecord {
@@ -161,6 +165,7 @@ message JobRecord {
   int32 workflowDefinitionVersion = 12;
   int64 processInstanceKey = 13;
   int64 processDefinitionKey = 14;
+  string tenantId = 15;
 }
 
 message JobBatchRecord {
@@ -173,6 +178,7 @@ message JobBatchRecord {
   repeated int64 jobKeys = 6;
   repeated JobRecord jobs = 7;
   bool truncated = 8;
+  repeated string tenantIds = 9;
 }
 
 message MessageRecord {
@@ -183,6 +189,7 @@ message MessageRecord {
   string messageId = 4;
   int64 timeToLive = 5;
   google.protobuf.Struct variables = 6;
+  string tenantId = 7;
 }
 
 message MessageSubscriptionRecord {
@@ -196,6 +203,7 @@ message MessageSubscriptionRecord {
   int64 messageKey = 7;
   google.protobuf.Struct variables = 8;
   bool isInterrupting = 9;
+  string tenantId = 10;
 }
 
 message MessageStartEventSubscriptionRecord {
@@ -209,6 +217,7 @@ message MessageStartEventSubscriptionRecord {
   int64 messageKey = 7;
   int64 processInstanceKey = 8;
   google.protobuf.Struct variables = 9;
+  string tenantId = 10;
 }
 
 message TimerRecord {
@@ -221,6 +230,7 @@ message TimerRecord {
   string targetElementId = 5;
   int64 processInstanceKey = 6;
   int64 processDefinitionKey = 7;
+  string tenantId = 8;
 }
 
 message VariableRecord {
@@ -232,6 +242,7 @@ message VariableRecord {
   int64 processInstanceKey = 5;
   int64 processDefinitionKey = 6;
   string bpmnProcessId = 7;
+  string tenantId = 8;
 }
 
 message VariableDocumentRecord {
@@ -247,6 +258,7 @@ message VariableDocumentRecord {
   int64 scopeKey = 2;
   UpdateSemantics updateSemantics = 3;
   google.protobuf.Struct variables = 4;
+  string tenantId = 5;
 }
 
 message ProcessInstanceRecord {
@@ -263,6 +275,7 @@ message ProcessInstanceRecord {
   int64 parentProcessInstanceKey = 9;
   int64 parentElementInstanceKey = 10;
   string bpmnEventType = 11;
+  string tenantId = 12;
 }
 
 message ProcessInstanceCreationRecord {
@@ -273,6 +286,7 @@ message ProcessInstanceCreationRecord {
   int64 processDefinitionKey = 4;
   int64 processInstanceKey = 5;
   google.protobuf.Struct variables = 6;
+  string tenantId = 7;
 }
 
 message ProcessMessageSubscriptionRecord {
@@ -287,6 +301,7 @@ message ProcessMessageSubscriptionRecord {
   string elementId = 8;
   string correlationKey = 9;
   bool isInterrupting = 10;
+  string tenantId = 11;
 }
 
 message ProcessRecord {
@@ -298,6 +313,7 @@ message ProcessRecord {
   string resourceName = 5;
   bytes checksum = 6;
   bytes resource = 7;
+  string tenantId = 8;
 }
 
 message ProcessEventRecord {
@@ -307,6 +323,7 @@ message ProcessEventRecord {
   int64 processDefinitionKey = 3;
   string targetElementId = 4;
   google.protobuf.Struct variables = 5;
+  string tenantId = 6;
 }
 
 message DecisionRecord {
@@ -318,6 +335,7 @@ message DecisionRecord {
   string decisionRequirementsId = 6;
   int64 decisionRequirementsKey = 7;
   bool isDuplicate = 8;
+  string tenantId = 9;
 }
 
 message DecisionRequirementsMetadata {
@@ -329,12 +347,14 @@ message DecisionRequirementsMetadata {
   string resourceName = 6;
   bytes checksum = 7;
   bool isDuplicate = 8;
+  string tenantId = 9;
 }
 
 message DecisionRequirementsRecord {
   RecordMetadata metadata = 1;
   DecisionRequirementsMetadata decisionRequirementsMetadata = 2;
   bytes resource = 3;
+  string tenantId = 4;
 }
 
 message DecisionEvaluationRecord {
@@ -348,6 +368,7 @@ message DecisionEvaluationRecord {
     string decisionOutput = 6;
     repeated EvaluatedInput evaluatedInputs = 7;
     repeated MatchedRule matchedRules = 8;
+    string tenantId = 9;
   }
 
   message MatchedRule {
@@ -384,6 +405,7 @@ message DecisionEvaluationRecord {
   string evaluationFailureMessage = 14;
   string failedDecisionId = 15;
   repeated EvaluatedDecision evaluatedDecisions = 16;
+  string tenantId = 17;
 }
 
 message ProcessInstanceModificationRecord {
@@ -408,6 +430,7 @@ message ProcessInstanceModificationRecord {
   int64 processInstanceKey = 2;
   repeated ProcessInstanceModificationTerminateInstruction terminateInstructions = 3;
   repeated ProcessInstanceModificationActivateInstruction activateInstructions = 4;
+  string tenantId = 5;
 }
 
 message CheckpointRecord {
@@ -420,6 +443,7 @@ message SignalRecord {
   RecordMetadata metadata = 1;
   string signalName = 2;
   google.protobuf.Struct variables = 3;
+  string tenantId = 4;
 }
 
 message SignalSubscriptionRecord {
@@ -429,4 +453,5 @@ message SignalSubscriptionRecord {
   string bpmnProcessId = 4;
   string catchEventId = 5;
   int64 catchEventInstanceKey = 6;
+  string tenantId = 7;
 }

--- a/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
+++ b/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
@@ -59,6 +59,7 @@ public class RecordTransformTest {
   public static final long TIMESTAMP = 1000L;
   public static final long SOURCE_POSITION = 100L;
   public static final Map<String, Object> VARIABLES = Map.of("foo", 23);
+  public static final String TENANT_ID = "tenant-42";
 
   @Test
   public void shouldTransformDeployment() {
@@ -92,6 +93,7 @@ public class RecordTransformTest {
     assertThat(processMetadata.getVersion()).isEqualTo(1);
     assertThat(processMetadata.getChecksum().toByteArray()).isEqualTo("checksum".getBytes());
     assertThat(processMetadata.getIsDuplicate()).isFalse();
+    assertThat(processMetadata.getTenantId()).isEqualTo(TENANT_ID);
 
     final var decisionRequirementsMetadataList = deployment.getDecisionRequirementsMetadataList();
     assertThat(decisionRequirementsMetadataList).hasSize(1);
@@ -116,6 +118,8 @@ public class RecordTransformTest {
         .isEqualTo(decisionRequirementsMetadata.getChecksum());
     assertThat(transformedDecisionRequirementsMetadata.getIsDuplicate())
         .isEqualTo(decisionRequirementsMetadata.isDuplicate());
+    assertThat(transformedDecisionRequirementsMetadata.getTenantId())
+        .isEqualTo(decisionRequirementsMetadata.getTenantId());
 
     final var decisionMetadataList = deployment.getDecisionMetadataList();
     assertThat(decisionMetadataList).hasSize(1);
@@ -136,6 +140,7 @@ public class RecordTransformTest {
         .isEqualTo(decisionMetadata.getDecisionKey());
     assertThat(transformedDecisionMetadata.getIsDuplicate())
         .isEqualTo(decisionMetadata.isDuplicate());
+    assertThat(transformedDecisionMetadata.getTenantId()).isEqualTo(decisionMetadata.getTenantId());
   }
 
   @Test
@@ -210,6 +215,7 @@ public class RecordTransformTest {
     assertThat(workflowInstance.getBpmnEventType()).isEqualTo("NONE");
     assertThat(workflowInstance.getParentProcessInstanceKey()).isEqualTo(-1L);
     assertThat(workflowInstance.getParentElementInstanceKey()).isEqualTo(-1L);
+    assertThat(workflowInstance.getTenantId()).isEqualTo(TENANT_ID);
   }
 
   @Test
@@ -235,6 +241,7 @@ public class RecordTransformTest {
         .isEqualTo(workflowInstanceCreationRecordValue.getProcessDefinitionKey());
     assertThat(workflowInstanceCreation.getVersion()).isEqualTo(1);
     assertThat(workflowInstanceCreation.getProcessInstanceKey()).isEqualTo(1L);
+    assertThat(workflowInstanceCreation.getTenantId()).isEqualTo(TENANT_ID);
     assertVariables(workflowInstanceCreation.getVariables());
   }
 
@@ -305,6 +312,7 @@ public class RecordTransformTest {
     assertThat(incidentRecord.getErrorType()).isEqualTo(ErrorType.JOB_NO_RETRIES.name());
 
     assertThat(incidentRecord.getJobKey()).isEqualTo(12L);
+    assertThat(incidentRecord.getTenantId()).isEqualTo(TENANT_ID);
   }
 
   @Test
@@ -325,6 +333,7 @@ public class RecordTransformTest {
     assertThat(messageRecord.getMessageId()).isEqualTo("msgId");
     assertThat(messageRecord.getName()).isEqualTo("message");
     assertThat(messageRecord.getTimeToLive()).isEqualTo(1000L);
+    assertThat(messageRecord.getTenantId()).isEqualTo(TENANT_ID);
 
     assertVariables(messageRecord.getVariables());
   }
@@ -349,6 +358,7 @@ public class RecordTransformTest {
     assertThat(timerRecord.getTargetElementId()).isEqualTo("timerCatch");
     assertThat(timerRecord.getProcessInstanceKey()).isEqualTo(2L);
     assertThat(timerRecord.getProcessDefinitionKey()).isEqualTo(3L);
+    assertThat(timerRecord.getTenantId()).isEqualTo(TENANT_ID);
   }
 
   @Test
@@ -372,7 +382,7 @@ public class RecordTransformTest {
     assertThat(messageSubscriptionRecord.getBpmnProcessId()).isEqualTo(value.getBpmnProcessId());
     assertThat(messageSubscriptionRecord.getMessageKey()).isEqualTo(value.getMessageKey());
     assertThat(messageSubscriptionRecord.getIsInterrupting()).isTrue();
-
+    assertThat(messageSubscriptionRecord.getTenantId()).isEqualTo(value.getTenantId());
     assertVariables(messageSubscriptionRecord.getVariables());
   }
 
@@ -408,7 +418,7 @@ public class RecordTransformTest {
         .isEqualTo(value.getCorrelationKey());
     assertThat(workflowInstanceSubscriptionRecord.getElementId()).isEqualTo(value.getElementId());
     assertThat(workflowInstanceSubscriptionRecord.getIsInterrupting()).isTrue();
-
+    assertThat(workflowInstanceSubscriptionRecord.getTenantId()).isEqualTo(value.getTenantId());
     assertVariables(workflowInstanceSubscriptionRecord.getVariables());
   }
 
@@ -433,6 +443,7 @@ public class RecordTransformTest {
     assertThat(variableRecord.getProcessDefinitionKey())
         .isEqualTo(variableRecordValue.getProcessDefinitionKey());
     assertThat(variableRecord.getBpmnProcessId()).isEqualTo(variableRecordValue.getBpmnProcessId());
+    assertThat(variableRecord.getTenantId()).isEqualTo(variableRecordValue.getTenantId());
   }
 
   @Test
@@ -455,6 +466,7 @@ public class RecordTransformTest {
     assertThat(variableRecord.getScopeKey()).isEqualTo(variableDocumentRecordValue.getScopeKey());
     assertThat(variableRecord.getUpdateSemantics().name())
         .isEqualTo(variableDocumentRecordValue.getUpdateSemantics().name());
+    assertThat(variableRecord.getTenantId()).isEqualTo(variableDocumentRecordValue.getTenantId());
     assertVariables(variableRecord.getVariables());
   }
 
@@ -482,6 +494,7 @@ public class RecordTransformTest {
     assertThat(transformed.getCorrelationKey()).isEqualTo(value.getCorrelationKey());
     assertThat(transformed.getMessageKey()).isEqualTo(value.getMessageKey());
     assertThat(transformed.getProcessInstanceKey()).isEqualTo(value.getProcessInstanceKey());
+    assertThat(transformed.getTenantId()).isEqualTo(value.getTenantId());
 
     assertVariables(transformed.getVariables());
   }
@@ -504,6 +517,7 @@ public class RecordTransformTest {
         .isEqualTo(recordValue.getProcessDefinitionKey());
     assertThat(transformedRecord.getScopeKey()).isEqualTo(recordValue.getScopeKey());
     assertThat(transformedRecord.getTargetElementId()).isEqualTo(recordValue.getTargetElementId());
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
 
     assertVariables(transformedRecord.getVariables());
   }
@@ -544,7 +558,13 @@ public class RecordTransformTest {
   public void shouldTransformValueType() {
 
     final var ignoredValueTypes =
-        Set.of(ValueType.NULL_VAL, ValueType.SBE_UNKNOWN, ValueType.PROCESS_INSTANCE_RESULT);
+        Set.of(
+            ValueType.NULL_VAL,
+            ValueType.SBE_UNKNOWN,
+            ValueType.PROCESS_INSTANCE_RESULT,
+            ValueType.PROCESS_INSTANCE_BATCH,
+            ValueType.MESSAGE_BATCH,
+            ValueType.FORM);
 
     final List<String> valueTypes =
         Arrays.stream(ValueType.values())
@@ -611,6 +631,7 @@ public class RecordTransformTest {
     assertThat(transformedRecord.getDecisionName()).isEqualTo(recordValue.getDecisionName());
     assertThat(transformedRecord.getDecisionKey()).isEqualTo(recordValue.getDecisionKey());
     assertThat(transformedRecord.getIsDuplicate()).isEqualTo(recordValue.isDuplicate());
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
   }
 
   @Test
@@ -644,6 +665,7 @@ public class RecordTransformTest {
         .isEqualTo(recordValue.getChecksum());
     assertThat(transformedRecord.getDecisionRequirementsMetadata().getIsDuplicate())
         .isEqualTo(recordValue.isDuplicate());
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
   }
 
   @Test
@@ -681,6 +703,7 @@ public class RecordTransformTest {
         .isEqualTo(recordValue.getEvaluationFailureMessage());
     assertThat(transformedRecord.getFailedDecisionId())
         .isEqualTo(recordValue.getFailedDecisionId());
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
 
     assertThat(transformedRecord.getEvaluatedDecisionsList()).hasSize(1);
     assertThat(recordValue.getEvaluatedDecisions()).hasSize(1);
@@ -693,6 +716,7 @@ public class RecordTransformTest {
   public void shouldTransformProcessInstanceModificationRecord() {
     // given
     final var recordValue = mock(ProcessInstanceModificationRecordValue.class);
+    when(recordValue.getTenantId()).thenReturn(TENANT_ID);
     when(recordValue.getProcessInstanceKey()).thenReturn(10L);
     when(recordValue.getActivateInstructions())
         .thenAnswer(
@@ -774,6 +798,7 @@ public class RecordTransformTest {
               assertThat(transformedInstruction.getElementInstanceKey())
                   .isEqualTo(terminateInstruction.getElementInstanceKey());
             });
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
   }
 
   @Test
@@ -803,6 +828,7 @@ public class RecordTransformTest {
     final var recordValue = mock(SignalRecordValue.class);
     when(recordValue.getSignalName()).thenReturn("signal");
     when(recordValue.getVariables()).thenReturn(VARIABLES);
+    when(recordValue.getTenantId()).thenReturn(TENANT_ID);
 
     final Record<SignalRecordValue> mockedRecord =
         mockRecord(recordValue, ValueType.SIGNAL, SignalIntent.BROADCAST);
@@ -815,6 +841,7 @@ public class RecordTransformTest {
     assertMetadata(transformedRecord.getMetadata(), "SIGNAL", "BROADCAST");
 
     assertThat(transformedRecord.getSignalName()).isEqualTo(recordValue.getSignalName());
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
     assertVariables(transformedRecord.getVariables());
   }
 
@@ -827,6 +854,7 @@ public class RecordTransformTest {
     when(recordValue.getBpmnProcessId()).thenReturn("process");
     when(recordValue.getCatchEventId()).thenReturn("event");
     when(recordValue.getCatchEventInstanceKey()).thenReturn(20L);
+    when(recordValue.getTenantId()).thenReturn(TENANT_ID);
 
     final Record<SignalSubscriptionRecordValue> mockedRecord =
         mockRecord(recordValue, ValueType.SIGNAL_SUBSCRIPTION, SignalSubscriptionIntent.CREATED);
@@ -845,6 +873,7 @@ public class RecordTransformTest {
     assertThat(transformedRecord.getCatchEventId()).isEqualTo(recordValue.getCatchEventId());
     assertThat(transformedRecord.getCatchEventInstanceKey())
         .isEqualTo(recordValue.getCatchEventInstanceKey());
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
   }
 
   private void assertEvaluatedDecision(
@@ -856,6 +885,7 @@ public class RecordTransformTest {
     assertThat(transformedRecord.getDecisionVersion()).isEqualTo(recordValue.getDecisionVersion());
     assertThat(transformedRecord.getDecisionType()).isEqualTo(recordValue.getDecisionType());
     assertThat(transformedRecord.getDecisionOutput()).isEqualTo(recordValue.getDecisionOutput());
+    assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
 
     assertThat(transformedRecord.getEvaluatedInputsList()).hasSize(1);
     assertThat(recordValue.getEvaluatedInputs()).hasSize(1);
@@ -906,8 +936,8 @@ public class RecordTransformTest {
     when(messageRecordValue.getMessageId()).thenReturn("msgId");
     when(messageRecordValue.getName()).thenReturn("message");
     when(messageRecordValue.getTimeToLive()).thenReturn(1000L);
-
     when(messageRecordValue.getVariables()).thenReturn(Collections.singletonMap("foo", 23));
+    when(messageRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return messageRecordValue;
   }
@@ -924,6 +954,7 @@ public class RecordTransformTest {
     when(value.getMessageKey()).thenReturn(2L);
     when(value.getProcessInstanceKey()).thenReturn(3L);
     when(value.getVariables()).thenReturn(VARIABLES);
+    when(value.getTenantId()).thenReturn(TENANT_ID);
 
     return value;
   }
@@ -937,6 +968,7 @@ public class RecordTransformTest {
     when(timerRecordValue.getTargetElementId()).thenReturn("timerCatch");
     when(timerRecordValue.getProcessInstanceKey()).thenReturn(2L);
     when(timerRecordValue.getProcessDefinitionKey()).thenReturn(3L);
+    when(timerRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return timerRecordValue;
   }
@@ -950,6 +982,7 @@ public class RecordTransformTest {
     when(variableRecordValue.getProcessInstanceKey()).thenReturn(1L);
     when(variableRecordValue.getProcessDefinitionKey()).thenReturn(2L);
     when(variableRecordValue.getBpmnProcessId()).thenReturn("process");
+    when(variableRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return variableRecordValue;
   }
@@ -961,6 +994,7 @@ public class RecordTransformTest {
     when(variableRecordValue.getUpdateSemantics())
         .thenReturn(VariableDocumentUpdateSemantic.PROPAGATE);
     when(variableRecordValue.getVariables()).thenReturn(Collections.singletonMap("foo", 23));
+    when(variableRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return variableRecordValue;
   }
@@ -977,6 +1011,7 @@ public class RecordTransformTest {
     when(messageSubscriptionRecordValue.getMessageKey()).thenReturn(2L);
     when(messageSubscriptionRecordValue.getVariables()).thenReturn(VARIABLES);
     when(messageSubscriptionRecordValue.isInterrupting()).thenReturn(true);
+    when(messageSubscriptionRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return messageSubscriptionRecordValue;
   }
@@ -997,6 +1032,7 @@ public class RecordTransformTest {
         .thenReturn(Collections.singletonMap("foo", 23));
     when(workflowInstanceSubscriptionRecordValue.isInterrupting()).thenReturn(true);
 
+    when(workflowInstanceSubscriptionRecordValue.getTenantId()).thenReturn(TENANT_ID);
     return workflowInstanceSubscriptionRecordValue;
   }
 
@@ -1011,6 +1047,7 @@ public class RecordTransformTest {
     when(jobBatchRecordValue.getType()).thenReturn("jobType");
     when(jobBatchRecordValue.getWorker()).thenReturn("myveryownworker");
     when(jobBatchRecordValue.isTruncated()).thenReturn(true);
+    when(jobBatchRecordValue.getTenantIds()).thenReturn(List.of(TENANT_ID));
 
     return jobBatchRecordValue;
   }
@@ -1033,6 +1070,7 @@ public class RecordTransformTest {
     when(jobRecordValue.getProcessDefinitionVersion()).thenReturn(1);
     when(jobRecordValue.getProcessInstanceKey()).thenReturn(1L);
     when(jobRecordValue.getProcessDefinitionKey()).thenReturn(4L);
+    when(jobRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return jobRecordValue;
   }
@@ -1048,6 +1086,7 @@ public class RecordTransformTest {
     when(processMetadata.getProcessDefinitionKey()).thenReturn(4L);
     when(processMetadata.getChecksum()).thenReturn("checksum".getBytes());
     when(processMetadata.isDuplicate()).thenReturn(false);
+    when(processMetadata.getTenantId()).thenReturn(TENANT_ID);
     workflows.add(processMetadata);
 
     when(deploymentRecordValue.getProcessesMetadata()).thenReturn(workflows);
@@ -1066,8 +1105,9 @@ public class RecordTransformTest {
     when(deploymentResource.getResource()).thenReturn("resourceContent".getBytes());
     when(deploymentResource.getResourceName()).thenReturn("process.bpmn");
     resources.add(deploymentResource);
-
     when(deploymentRecordValue.getResources()).thenReturn(resources);
+
+    when(deploymentRecordValue.getTenantId()).thenReturn(TENANT_ID);
     return deploymentRecordValue;
   }
 
@@ -1085,6 +1125,7 @@ public class RecordTransformTest {
     when(value.getVersion()).thenReturn(1);
     when(value.getProcessDefinitionKey()).thenReturn(2L);
     when(value.getChecksum()).thenReturn("checksum".getBytes());
+    when(value.getTenantId()).thenReturn(TENANT_ID);
     return value;
   }
 
@@ -1102,6 +1143,7 @@ public class RecordTransformTest {
     when(workflowInstanceRecordValue.getBpmnEventType()).thenReturn(BpmnEventType.NONE);
     when(workflowInstanceRecordValue.getParentProcessInstanceKey()).thenReturn(-1L);
     when(workflowInstanceRecordValue.getParentElementInstanceKey()).thenReturn(-1L);
+    when(workflowInstanceRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return workflowInstanceRecordValue;
   }
@@ -1116,6 +1158,7 @@ public class RecordTransformTest {
     when(workflowInstanceCreationRecordValue.getProcessInstanceKey()).thenReturn(1L);
     when(workflowInstanceCreationRecordValue.getVariables())
         .thenReturn(Collections.singletonMap("foo", 23));
+    when(workflowInstanceCreationRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return workflowInstanceCreationRecordValue;
   }
@@ -1134,6 +1177,7 @@ public class RecordTransformTest {
     when(incidentRecordValue.getErrorType()).thenReturn(ErrorType.JOB_NO_RETRIES);
 
     when(incidentRecordValue.getJobKey()).thenReturn(12L);
+    when(incidentRecordValue.getTenantId()).thenReturn(TENANT_ID);
 
     return incidentRecordValue;
   }
@@ -1144,6 +1188,7 @@ public class RecordTransformTest {
     when(value.getScopeKey()).thenReturn(2L);
     when(value.getTargetElementId()).thenReturn("targetElementId");
     when(value.getVariables()).thenReturn(VARIABLES);
+    when(value.getTenantId()).thenReturn(TENANT_ID);
     return value;
   }
 
@@ -1156,6 +1201,7 @@ public class RecordTransformTest {
     when(value.getDecisionName()).thenReturn("decisionName");
     when(value.getDecisionKey()).thenReturn(3L);
     when(value.isDuplicate()).thenReturn(false);
+    when(value.getTenantId()).thenReturn(TENANT_ID);
     return value;
   }
 
@@ -1170,6 +1216,7 @@ public class RecordTransformTest {
     when(value.getChecksum()).thenReturn("checksum".getBytes());
     when(value.getResource()).thenReturn("resource".getBytes());
     when(value.isDuplicate()).thenReturn(false);
+    when(value.getTenantId()).thenReturn(TENANT_ID);
     return value;
   }
 
@@ -1195,6 +1242,7 @@ public class RecordTransformTest {
     final List<EvaluatedDecisionValue> evaluatedDecisions =
         Collections.singletonList(mockEvaluatedDecisionValue());
     when(value.getEvaluatedDecisions()).thenReturn(evaluatedDecisions);
+    when(value.getTenantId()).thenReturn(TENANT_ID);
     return value;
   }
 
@@ -1213,7 +1261,7 @@ public class RecordTransformTest {
     when(value.getEvaluatedInputs()).thenReturn(evaluatedInputs);
     final List<MatchedRuleValue> matchedRules = Collections.singletonList(mockMatchedRuleValue());
     when(value.getMatchedRules()).thenReturn(matchedRules);
-
+    when(value.getTenantId()).thenReturn(TENANT_ID);
     return value;
   }
 
@@ -1277,6 +1325,7 @@ public class RecordTransformTest {
     assertThat(jobRecord.getRetries()).isEqualTo(3);
     assertThat(jobRecord.getType()).isEqualTo("jobType");
     assertThat(jobRecord.getWorker()).isEqualTo("myveryownworker");
+    assertThat(jobRecord.getTenantId()).isEqualTo(TENANT_ID);
   }
 
   private void assertMetadata(

--- a/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
+++ b/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
@@ -562,6 +562,7 @@ public class RecordTransformTest {
             ValueType.NULL_VAL,
             ValueType.SBE_UNKNOWN,
             ValueType.PROCESS_INSTANCE_RESULT,
+            // below are general TODOs for Zeebe 8.3.x
             ValueType.PROCESS_INSTANCE_BATCH,
             ValueType.MESSAGE_BATCH,
             ValueType.FORM);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Support multi-tenancy in Zeebe 8.3.x

* Updated Zeebe version to 8.3.5
* Added the attribute `tenantId` to schema and transformer
* Updated the tests accordingly

BEWARE: in order to fully support Zeebe 8.3.x, e.g. new ValueTypes `PROCESS_INSTANCE_BATCH`, `MESSAGE_BATCH` and `FORM` there is more to do. But supporting multi-tenancy might be good start.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #313
