### PR TITLE
feat: Add user task properties from Camunda 8.5

### DIFF
--- a/src/main/java/io/zeebe/exporter/proto/RecordTransformer.java
+++ b/src/main/java/io/zeebe/exporter/proto/RecordTransformer.java
@@ -809,6 +809,11 @@ public final class RecordTransformer {
         .setTenantId(toTenantId(value))
         .addAllCandidateGroup(value.getCandidateGroupsList())
         .addAllCandidateUser(value.getCandidateUsersList())
+        .setExternalFormReference(value.getExternalFormReference())
+        .setCustomHeaders(toStruct(value.getCustomHeaders()))
+        .addAllChangedAttribute(value.getChangedAttributes())
+        .setAction(value.getAction())
+        .setCreationTimestamp(value.getCreationTimestamp())
         // === deprecated properties
         .setCandidateGroups(String.join(",", value.getCandidateGroupsList()))
         .setCandidateUsers(String.join(",", value.getCandidateUsersList()))

--- a/src/main/proto/schema.proto
+++ b/src/main/proto/schema.proto
@@ -509,7 +509,11 @@ message UserTaskRecord {
   string elementId = 14;
   int64 elementInstanceKey = 15;
   string tenantId = 16;
-
   repeated string candidateGroup = 17;
   repeated string candidateUser = 18;
+  string externalFormReference = 19;
+  google.protobuf.Struct customHeaders = 20;
+  repeated string changedAttribute = 21;
+  string action = 22;
+  int64 creationTimestamp = 23;
 }

--- a/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
+++ b/src/test/java/io/zeebe/exporter/proto/RecordTransformTest.java
@@ -936,8 +936,10 @@ public class RecordTransformTest {
 
     assertThat(transformedRecord.getUserTaskKey()).isEqualTo(recordValue.getUserTaskKey());
     assertThat(transformedRecord.getAssignee()).isEqualTo(recordValue.getAssignee());
-    assertThat(transformedRecord.getCandidateGroupList()).isEqualTo(recordValue.getCandidateGroupsList());
-    assertThat(transformedRecord.getCandidateUserList()).isEqualTo(recordValue.getCandidateUsersList());
+    assertThat(transformedRecord.getCandidateGroupList())
+        .isEqualTo(recordValue.getCandidateGroupsList());
+    assertThat(transformedRecord.getCandidateUserList())
+        .isEqualTo(recordValue.getCandidateUsersList());
     assertThat(transformedRecord.getDueDate()).isEqualTo(recordValue.getDueDate());
     assertThat(transformedRecord.getFollowUpDate()).isEqualTo(recordValue.getFollowUpDate());
     assertThat(transformedRecord.getFormKey()).isEqualTo(recordValue.getFormKey());
@@ -953,6 +955,14 @@ public class RecordTransformTest {
         .isEqualTo(recordValue.getElementInstanceKey());
     assertThat(transformedRecord.getTenantId()).isEqualTo(recordValue.getTenantId());
     assertVariables(transformedRecord.getVariables());
+    assertThat(transformedRecord.getExternalFormReference())
+        .isEqualTo(recordValue.getExternalFormReference());
+    assertStruct(transformedRecord.getCustomHeaders(), recordValue.getCustomHeaders());
+    assertThat(transformedRecord.getChangedAttributeList())
+        .isEqualTo(recordValue.getChangedAttributes());
+    assertThat(transformedRecord.getAction()).isEqualTo(recordValue.getAction());
+    assertThat(transformedRecord.getCreationTimestamp())
+        .isEqualTo(recordValue.getCreationTimestamp());
 
     assertThat(transformedRecord.getCandidateGroups()).isEqualTo("group1,group2");
     assertThat(transformedRecord.getCandidateUsers()).isEqualTo("user1,user2");
@@ -1424,6 +1434,11 @@ public class RecordTransformTest {
     when(value.getElementId()).thenReturn("element-id");
     when(value.getElementInstanceKey()).thenReturn(6L);
     when(value.getTenantId()).thenReturn(TENANT_ID);
+    when(value.getExternalFormReference()).thenReturn("external-form-reference");
+    when(value.getCustomHeaders()).thenReturn(Map.of("custom-header", "h1"));
+    when(value.getChangedAttributes()).thenReturn(List.of("a1", "a2"));
+    when(value.getAction()).thenReturn("action");
+    when(value.getCreationTimestamp()).thenReturn(7L);
     return value;
   }
 
@@ -1431,6 +1446,19 @@ public class RecordTransformTest {
     assertThat(payload.getFieldsCount()).isEqualTo(1);
     assertThat(payload.getFieldsMap())
         .containsExactly(entry("foo", Value.newBuilder().setNumberValue(23).build()));
+  }
+
+  private void assertStruct(final Struct actual, final Map<String, String> expected) {
+    assertThat(actual.getFieldsCount()).isEqualTo(expected.size());
+    assertThat(actual.getFieldsMap().keySet()).containsExactlyElementsOf(expected.keySet());
+    assertThat(actual.getFieldsMap())
+        .allSatisfy(
+            (key, value) -> {
+              final Object expectedValue = expected.get(key);
+              assertThat(expectedValue).isInstanceOf(String.class);
+              assertThat(value.getKindCase()).isEqualTo(Value.KindCase.STRING_VALUE);
+              assertThat(expectedValue).isEqualTo(value.getStringValue());
+            });
   }
 
   private void assertJobRecord(final JobRecord jobRecord) {


### PR DESCRIPTION
## Description

* Extend the user task record by the new properties from Zeebe version 8.5 ([ref](https://github.com/camunda/zeebe/blob/8.5.0/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java))

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #341 
