### PR TITLE
Roll back incompatible google protobuf version 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
     <!-- project dependencies -->
     <version.zeebe>8.5.1</version.zeebe>
 
-    <version.protobuf>4.26.1</version.protobuf>
-    <version.protoc>4.26.1</version.protoc>
+    <version.protobuf>3.25.3</version.protobuf>
+    <version.protoc>3.25.3</version.protoc>
     <version.slf4j>1.7.25</version.slf4j>
 
     <version.assertj>3.25.3</version.assertj>

--- a/src/main/java/io/zeebe/exporter/proto/RecordTransformer.java
+++ b/src/main/java/io/zeebe/exporter/proto/RecordTransformer.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  */
 public final class RecordTransformer {
 
-  private static final EnumMap<ValueType, Function<Record, GeneratedMessage>> TRANSFORMERS =
+  private static final EnumMap<ValueType, Function<Record, GeneratedMessageV3>> TRANSFORMERS =
       new EnumMap<>(ValueType.class);
 
   private static final EnumMap<ValueType, RecordMetadata.ValueType> VALUE_TYPE_MAPPING =
@@ -155,9 +155,9 @@ public final class RecordTransformer {
 
   private RecordTransformer() {}
 
-  public static GeneratedMessage toProtobufMessage(Record record) {
+  public static GeneratedMessageV3 toProtobufMessage(Record record) {
     final ValueType valueType = record.getValueType();
-    final Function<Record, GeneratedMessage> toRecordFunc = TRANSFORMERS.get(valueType);
+    final Function<Record, GeneratedMessageV3> toRecordFunc = TRANSFORMERS.get(valueType);
     return toRecordFunc != null ? toRecordFunc.apply(record) : Empty.getDefaultInstance();
   }
 


### PR DESCRIPTION
## Description

Thanks a lot for updating this exporter especially with the important UserTask events and all the other Zeebe 8.5 details. I really appreciate that 👍 

Sadly the upgrade to google-protobuf version 4.x causes incompatibilities with the older 3.x version included in the current 8.5.1 versions of zeebe-client-java, zeebe-gateway-protocol-impl, etc. I get exceptions like `java.lang.NoClassDefFoundError: com/google/protobuf/GeneratedMessageV3`

Is there a specific reason to use the newer protobuf version? I think this should stay in sync with the major version used in all other parts of Zeebe.

If rolling back this dependency version is no option for you - is it possible to build a special protobuf-3.x version of the protobuf-exporter in parallel?

If you're fine with the changes: this PR just rolls back the protobuf library version to 3.x. and leaves everything else as required for Camunda 8.5. It would be great to publish this as version 1.6.1 of `zeebe-exporter-protobuf`
