### PR TITLE
chore: prepare migration to Sonatype Central Portal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,16 @@ jobs:
         gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
         gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
     - name: Deploy SNAPSHOT / Release
-      uses: camunda-community-hub/community-action-maven-release@v1 # pin@v1
+      uses: camunda-community-hub/community-action-maven-release@v2 # pin@v1
       with:
         release-version: ${{ github.event.release.tag_name }}
         release-profile: community-action-maven-release
         nexus-usr: ${{ secrets.NEXUS_USR }}
         nexus-psw: ${{ secrets.NEXUS_PSW }}
+        sonatype-central-portal-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_USR }}
+        sonatype-central-portal-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_CP_PSW }}
+        # maven-usr, maven-psw and maven-url are deprecated; they are required only for publishing to the legacy OSS Sonatype repository.
+        # Once the io.zeebe namespace is migrated to the Sonatype Central Portal, these can be safely removed.
         maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
         maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
         maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>1.4.4</version>
+    <version>2.0.0</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Description

This PR prepares for the upcoming migration from OSSRH to the new Sonatype Central Portal, as announced in [camunda-community-hub/discussions#172](https://github.com/orgs/camunda-community-hub/discussions/172).

Changes:
- Upgrade parent POM to version `2.0.0`
- Use the `@v2` tag of `camunda-community-hub/community-action-maven-release`, updating inputs accordingly

These changes help ensure a smooth transition ahead of the transition.